### PR TITLE
Add test-unit gem to development dependency

### DIFF
--- a/fluent-plugin-anonymizer.gemspec
+++ b/fluent-plugin-anonymizer.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
+  spec.add_development_dependency "test-unit", "~> 3"
   spec.add_runtime_dependency "fluentd"
   spec.add_runtime_dependency "fluent-mixin-rewrite-tag-name"
 end


### PR DESCRIPTION
Because Ruby 2.2 does not bundle unit testing library like test-unit.