### PR TITLE
Add config descriptions

### DIFF
--- a/lib/fluent/plugin/filter_anonymizer.rb
+++ b/lib/fluent/plugin/filter_anonymizer.rb
@@ -2,8 +2,6 @@ module Fluent
   class AnonymizerFilter < Filter
     Plugin.register_filter('anonymizer', self)
 
-    config_param :tag, :string, :default => nil,
-                 :desc => 'The output tag.'
     config_param :hash_salt, :string, :default => '',
                  :desc => <<-DESC
 This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.

--- a/lib/fluent/plugin/filter_anonymizer.rb
+++ b/lib/fluent/plugin/filter_anonymizer.rb
@@ -2,10 +2,17 @@ module Fluent
   class AnonymizerFilter < Filter
     Plugin.register_filter('anonymizer', self)
 
-    config_param :tag, :string, :default => nil
-    config_param :hash_salt, :string, :default => ''
-    config_param :ipv4_mask_subnet, :integer, :default => 24
-    config_param :ipv6_mask_subnet, :integer, :default => 104
+    config_param :tag, :string, :default => nil,
+                 :desc => 'The output tag.'
+    config_param :hash_salt, :string, :default => '',
+                 :desc => <<-DESC
+This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.
+It is recommend to set a hash salt to prevent rainbow table attacks.
+DESC
+    config_param :ipv4_mask_subnet, :integer, :default => 24,
+                 :desc => 'Anonymize ipv4 addresses by subnet mask.'
+    config_param :ipv6_mask_subnet, :integer, :default => 104,
+                 :desc => 'Anonymize ipv6 addresses by subnet mask.'
 
     config_set_default :include_tag_key, false
 

--- a/lib/fluent/plugin/out_anonymizer.rb
+++ b/lib/fluent/plugin/out_anonymizer.rb
@@ -13,10 +13,17 @@ class Fluent::AnonymizerOutput < Fluent::Output
     define_method("router") { Fluent::Engine }
   end
 
-  config_param :tag, :string, :default => nil
-  config_param :hash_salt, :string, :default => ''
-  config_param :ipv4_mask_subnet, :integer, :default => 24
-  config_param :ipv6_mask_subnet, :integer, :default => 104
+  config_param :tag, :string, :default => nil,
+               :desc => 'The output tag.'
+  config_param :hash_salt, :string, :default => '',
+               :desc => <<-DESC
+This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.
+It is recommend to set a hash salt to prevent rainbow table attacks.
+DESC
+  config_param :ipv4_mask_subnet, :integer, :default => 24,
+               :desc => 'Anonymize ipv4 addresses by subnet mask.'
+  config_param :ipv6_mask_subnet, :integer, :default => 104,
+               :desc => 'Anonymize ipv6 addresses by subnet mask.'
 
   include Fluent::HandleTagNameMixin
   include Fluent::Mixin::RewriteTagName


### PR DESCRIPTION
Hi, @y-ken !
It would be great to support config descriptions feature in this plugins.

Fluentd 0.12.16 or later supports config descriptions feature.
This feature works as below:

```log
$ bundle exec fluentd --show-plugin-config output:anonymizer -p lib/fluent/plugin/
2015-12-10 12:17:04 +0900 [info]: Show config for output:anonymizer
2015-12-10 12:17:04 +0900 [info]: 
tag: string: <nil> # The output tag.
hash_salt: string: <""> # This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.
It is recommend to set a hash salt to prevent rainbow table attacks.

ipv4_mask_subnet: integer: <24> # Anonymize ipv4 addresses by subnet mask.
ipv6_mask_subnet: integer: <104> # Anonymize ipv6 addresses by subnet mask.

$ bundle exec fluentd --show-plugin-config filter:anonymizer -p lib/fluent/plugin/
2015-12-10 12:19:00 +0900 [info]: Show config for filter:anonymizer
2015-12-10 12:19:00 +0900 [info]: 
hash_salt: string: <""> # This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.
It is recommend to set a hash salt to prevent rainbow table attacks.

ipv4_mask_subnet: integer: <24> # Anonymize ipv4 addresses by subnet mask.
ipv6_mask_subnet: integer: <104> # Anonymize ipv6 addresses by subnet mask.
```