### PR TITLE
Fix version notation in Appraisals

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -1,7 +1,7 @@
 appraise "fluentd v0.10" do
-  gem "fluentd", "~> 0.10"
+  gem "fluentd", "~> 0.10.0"
 end
 
 appraise "fluentd v0.12" do
-  gem "fluentd", "~> 0.12"
+  gem "fluentd", "~> 0.12.0"
 end

--- a/gemfiles/fluentd_v0.10.gemfile
+++ b/gemfiles/fluentd_v0.10.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "fluentd", "~> 0.10"
+gem "fluentd", "~> 0.10.0"
 
 gemspec :path => "../"

--- a/gemfiles/fluentd_v0.12.gemfile
+++ b/gemfiles/fluentd_v0.12.gemfile
@@ -2,6 +2,6 @@
 
 source "http://rubygems.org"
 
-gem "fluentd", "~> 0.12"
+gem "fluentd", "~> 0.12.0"
 
 gemspec :path => "../"

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -23,7 +23,10 @@ unless ENV.has_key?('VERBOSE')
 end
 
 require 'fluent/plugin/out_anonymizer'
-require 'fluent/plugin/filter_anonymizer'
+if Fluent.const_defined?(:Filter)
+  require 'fluent/plugin/filter_anonymizer'
+end
+
 
 class Test::Unit::TestCase
 end

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -2,6 +2,7 @@ require 'helper'
 
 class AnonymizerFilterTest < Test::Unit::TestCase
   def setup
+    omit_unless(Fluent.const_defined?(:Filter))
     Fluent::Test.setup
     @time = Fluent::Engine.now
   end


### PR DESCRIPTION
* In previous version, "~> 0.10" installs "0.12.20"
* In this version, "~> 0.10.0" installs "0.10.61"