### PR TITLE
Rewrite implementation

### DIFF
--- a/lib/fluent/plugin/anonymizer.rb
+++ b/lib/fluent/plugin/anonymizer.rb
@@ -79,7 +79,7 @@ module Fluent
     def anonymize_value(message, algorithm, salt)
       case algorithm
       when 'md5','sha1','sha256','sha384','sha512'
-        OpenSSL::HMAC.hexdigest(DIGEST[algorithm].call, salt, message.to_s)
+        DIGEST[algorithm].call.update(salt).update(message.to_s).hexdigest
       when 'ipaddr_mask'
         address = IPAddr.new(message)
         subnet = address.ipv4? ? @ipv4_mask_subnet : @ipv6_mask_subnet

--- a/lib/fluent/plugin/filter_anonymizer.rb
+++ b/lib/fluent/plugin/filter_anonymizer.rb
@@ -236,7 +236,7 @@ module Fluent
       heading = key_chain[0..-2]
       container_fetcher = ->(record){ heading.reduce(record){|r,c| r && r.has_key?(c) ? r[c] : nil } }
       tailing = key_chain[-1]
-      ->(record) {
+      ->(record){
         begin
           container = container_fetcher.call(record)
           if container && container.has_key?(tailing)
@@ -252,7 +252,7 @@ module Fluent
     def masker_for_key_pattern(conv, pattern, opts)
       for_each = opts.mask_array_elements
       regexp = Regexp.new(pattern)
-      -> (record){
+      ->(record){
         begin
           record.each_pair do |key, value|
             next unless (regexp =~ key.to_s rescue nil)
@@ -267,7 +267,7 @@ module Fluent
 
     def masker_for_value_pattern(conv, pattern, opts)
       regexp = Regexp.new(pattern)
-      -> (record){
+      ->(record){
         begin
           record.each_pair do |key, value|
             next unless (regexp =~ value.to_s rescue nil)

--- a/lib/fluent/plugin/filter_anonymizer.rb
+++ b/lib/fluent/plugin/filter_anonymizer.rb
@@ -1,31 +1,238 @@
+require 'fluent/filter'
+require 'openssl'
+require 'uri'
+require 'ipaddr'
+
+# <filter **>
+#   @type mask
+#   # salts will be selected for field names in a deterministic way
+#   salt secret_salt # different salt for each fields?
+#   salt salt_brabra
+#   salts s1,s2,s3,s4
+#   <mask sha1>
+#     # key user_id
+#     keys ["user_id","session_id","source_ip"]
+#     key_pattern   ^(source|src)_?ip_?(addr|address)?$
+#     value_pattern   @mydomain\.example\.com$
+#     value_in_subnet 192.168.0.0/16 # naming?
+#   </mask>
+#   <mask uri_path>
+#     keys ["url","uri"]
+#     # or key_pattern
+#   </mask>
+#   <mask network>
+#     keys ["dest","destination","dest_ip"]
+#     # or key_pattern
+#     ipv4_mask_bits 24
+#     ipv6_mask_bits 104
+#   </mask>
+# </filter>
+
 module Fluent
   class AnonymizerFilter < Filter
-    Plugin.register_filter('anonymizer', self)
+    Fluent::Plugin.register_filter('anonymizer', self)
 
-    config_param :hash_salt, :string, :default => '',
-                 :desc => <<-DESC
-This salt affects for md5_keys sha1_keys sha256_keys sha384_keys sha512_keys settings.
-It is recommend to set a hash salt to prevent rainbow table attacks.
-DESC
-    config_param :ipv4_mask_subnet, :integer, :default => 24,
-                 :desc => 'Anonymize ipv4 addresses by subnet mask.'
-    config_param :ipv6_mask_subnet, :integer, :default => 104,
-                 :desc => 'Anonymize ipv6 addresses by subnet mask.'
+    MASK_METHODS = {
+      md5:    ->(opts){ ->(v,salt){ OpenSSL::Digest.new("md5").update(salt).update(v.to_s).hexdigest } },
+      sha1:   ->(opts){ ->(v,salt){ OpenSSL::Digest.new("sha1").update(salt).update(v.to_s).hexdigest } },
+      sha256: ->(opts){ ->(v,salt){ OpenSSL::Digest.new("sha256").update(salt).update(v.to_s).hexdigest } },
+      sha384: ->(opts){ ->(v,salt){ OpenSSL::Digest.new("sha384").update(salt).update(v.to_s).hexdigest } },
+      sha512: ->(opts){ ->(v,salt){ OpenSSL::Digest.new("sha512").update(salt).update(v.to_s).hexdigest } },
+      uri_path: ->(opts){ ->(v,salt){
+          begin
+            uri = URI.parse(v)
+            if uri.absolute?
+              uri.path = '/'
+              uri.user = uri.password = uri.query = uri.fragment = nil
+            end
+            uri.to_s
+          rescue
+            v
+          end
+        } },
+      network: ->(opts){ ->(v,salt){
+          begin
+            addr = IPAddr.new(v)
+            if addr.ipv4? && opts.ipv4_mask_bits
+              addr.mask(opts.ipv4_mask_bits).to_s
+            elsif addr.ipv6? && opts.ipv6_mask_bits
+              addr.mask(opts.ipv6_mask_bits).to_s
+            else
+              addr.to_s
+            end
+          rescue
+            v
+          end
+        } },
+    }
 
-    config_set_default :include_tag_key, false
+    config_param :salt, default: nil do |value|
+      @salt_list << value.strip.to_s
+    end
+    config_param :salts, default: nil do |values|
+      values.split(',').map(&:strip).each do |value|
+        @salt_list << value
+      end
+    end
+    config_section :mask, param_name: :mask_config_list, required: false, multi: true do
+      config_argument :method, :enum, list: MASK_METHODS.keys
+      config_param :salt, :string, default: nil
+
+      config_param :key, :string, default: nil
+      config_param :keys, :array, default: []
+      config_param :key_pattern, :string, default: nil
+      config_param :value_pattern, :string, default: nil
+      config_param :value_in_subnet, :string, default: nil # 192.168.0.0/24
+
+      config_param :ipv4_mask_bits, :integer, default: nil
+      config_param :ipv6_mask_bits, :integer, default: nil
+    end
+
+    # obsolete configuration parameters
+    config_param :md5_keys,    :string, default: nil
+    config_param :sha1_keys,   :string, default: nil
+    config_param :sha256_keys, :string, default: nil
+    config_param :sha384_keys, :string, default: nil
+    config_param :sha512_keys, :string, default: nil
+    config_param :hash_salt,   :string, default: nil
+    config_param :ipaddr_mask_keys, :string, default: nil
+    config_param :ipv4_mask_subnet, :integer, default: 24
+    config_param :ipv6_mask_subnet, :integer, default: 104
 
     def initialize
       super
-      require 'fluent/plugin/anonymizer'
+      @salt_list = []
+      @salt_map = {}
+      @conversions = []
     end
 
     def configure(conf)
       super
-      @anonymizer = Anonymizer.new(self, conf)
+
+      salt_missing = false
+
+      @masks = []
+      @mask_config_list.each do |c|
+        unless c.salt || @salt_list.size > 0
+          salt_missing = true
+        end
+
+        conv = MASK_METHODS[c.method].call(c)
+        [c.key || nil, *c.keys].compact.each do |key|
+          @masks << masker_for_key(conv, key, c.salt)
+        end
+        @masks << masker_for_key_pattern(conv, c.key_pattern, c.salt) if c.key_pattern
+        @masks << masker_for_value_pattern(conv, c.value_pattern, c.salt) if c.value_pattern
+        @masks << masker_for_value_in_subnet(conv, c.value_in_subnet, c.salt) if c.value_in_subnet
+      end
+
+      # obsolete option handling
+      [[@md5_keys,:md5],[@sha1_keys,:sha1],[@sha256_keys,:sha256],[@sha384_keys,:sha384],[@sha512_keys,:sha512]].each do |param,m|
+        next unless param
+        @salt_list << (@hash_salt || '') if @salt_list.empty?
+        conv = MASK_METHODS[m].call(OpenStruct.new)
+        param.split(',').map(&:strip).each do |key|
+          @masks << masker_for_key(conv, key, @hash_salt || '')
+        end
+      end
+      if @ipaddr_mask_keys
+        @salt_list << (@hash_salt || '') if @salt_list.empty?
+        conf = OpenStruct.new
+        conf.ipv4_mask_bits = @ipv4_mask_subnet
+        conf.ipv6_mask_bits = @ipv6_mask_subnet
+        conv = MASK_METHODS[:network].call(conf)
+        @ipaddr_mask_keys.split(',').map(&:strip).each do |key|
+          @masks << masker_for_key(conv, key, @hash_salt || '')
+        end
+      end
+
+      if @masks.size < 1
+        raise Fluent::ConfigError, "no anonymizing operations configured"
+      end
+      if salt_missing
+        raise Fluent::ConfigError, "salt (or salts) required, but missing"
+      end
     end
 
     def filter(tag, time, record)
-      record = @anonymizer.anonymize(record)
+      record.update(@masks.reduce(record){|r,mask| mask.call(r)})
+    end
+
+    def filter_stream(tag, es)
+      new_es = MultiEventStream.new
+      es.each do |time, record|
+        new_es.add(time, @masks.reduce(record){|r,mask| mask.call(r) })
+      end
+      new_es
+    end
+
+    def salt_determine(key)
+      return @salt_map[key] if @salt_map.has_key?(key)
+      keystr = key.to_s
+      if keystr.empty?
+        @salt_map[key] = @salt_list[0]
+      else
+        @salt_map[key] = @salt_list[(keystr[0].ord + keystr[-1].ord) % @salt_map.size]
+      end
+      @salt_map[key]
+    end
+
+    def masker_for_key(conv, key, salt)
+      ->(record){
+        begin
+          if record.has_key?(key)
+            record[key] = conv.call(record[key], salt || salt_determine(key))
+          end
+        rescue => e
+          log.error "unexpected error while masking value", error_class: e.class, error: e.message
+        end
+        record
+      }
+    end
+
+    def masker_for_key_pattern(conv, pattern, salt)
+      regexp = Regexp.new(pattern)
+      -> (record){
+        begin
+          record.each_pair do |key, value|
+            next unless (regexp =~ key.to_s rescue nil)
+            record[key] = conv.call(value, salt || salt_determine(key))
+          end
+        rescue => e
+          log.error "unexpected error while masking value", error_class: e.class, error: e.message
+        end
+        record
+      }
+    end
+
+    def masker_for_value_pattern(conv, pattern, salt)
+      regexp = Regexp.new(pattern)
+      -> (record){
+        begin
+          record.each_pair do |key, value|
+            next unless (regexp =~ value.to_s rescue nil)
+            record[key] = conv.call(value, salt || salt_determine(key))
+          end
+        rescue => e
+          log.error "unexpected error while masking value", error_class: e.class, error: e.message
+        end
+        record
+      }
+    end
+
+    def masker_for_value_in_subnet(conv, network_str, salt)
+      network = IPAddr.new(network_str)
+      ->(record){
+        begin
+          record.each_pair do |key, value|
+            next unless (network.include?(value) rescue nil)
+            record[key] = conv.call(value, salt || salt_determine(key))
+          end
+        rescue => e
+          log.error "unexpected error while masking value", error_class: e.class, error: e.message
+        end
+        record
+      }
     end
   end
 end

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -92,9 +92,10 @@ class AnonymizerFilterTest < Test::Unit::TestCase
   end
 
   test 'masker_for_key generates a lambda for conversion with exact key match' do
+    conf = OpenStruct.new(salt: 's')
     plugin = create_driver.instance
     conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
-    masker = plugin.masker_for_key(conv, 'kkk', 's')
+    masker = plugin.masker_for_key(conv, 'kkk', conf)
     r = masker.call({"k" => "x", "kk" => "xx", "kkk" => "xxx", "kkkk" => "xxxx"})
     assert_equal "x", r["k"]
     assert_equal "xx", r["kk"]
@@ -104,9 +105,10 @@ class AnonymizerFilterTest < Test::Unit::TestCase
   end
 
   test 'masker_for_key_pattern generates a lambda for conversion with key pattern match' do
+    conf = OpenStruct.new(salt: 's')
     plugin = create_driver.instance
     conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
-    masker = plugin.masker_for_key_pattern(conv, '^k+$', 's')
+    masker = plugin.masker_for_key_pattern(conv, '^k+$', conf)
     r = masker.call({"k" => "x", "kk" => "xx", "kkk" => "xxx", "kkk0" => "xxxx", "f" => "x", "ff" => "xx"})
     assert_equal "X:s", r["k"]
     assert_equal "XX:s", r["kk"]
@@ -118,9 +120,10 @@ class AnonymizerFilterTest < Test::Unit::TestCase
   end
 
   test 'masker_for_value_pattern' do
+    conf = OpenStruct.new(salt: 's')
     plugin = create_driver.instance
     conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
-    masker = plugin.masker_for_value_pattern(conv, '^x+$', 's')
+    masker = plugin.masker_for_value_pattern(conv, '^x+$', conf)
     r = masker.call({"k" => "x", "kk" => "x0", "kkk" => "xx0", "kkk0" => "xxxx", "f" => "x", "ff" => "xx"})
     assert_equal "X:s", r["k"]
     assert_equal "x0", r["kk"]
@@ -132,9 +135,10 @@ class AnonymizerFilterTest < Test::Unit::TestCase
   end
 
   test 'masker_for_value_in_subnet' do
+    conf = OpenStruct.new(salt: 's')
     plugin = create_driver.instance
     conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
-    masker = plugin.masker_for_value_in_subnet(conv, '192.168.0.0/16', 's')
+    masker = plugin.masker_for_value_in_subnet(conv, '192.168.0.0/16', conf)
     r = masker.call({"k1" => "x", "k2" => "192.169.1.1", "k3" => "192.168.128.13", "f1" => "x", "f2" => "10.0.12.1", "f3" => "192.168.1.1"})
     assert_equal "x", r["k1"]
     assert_equal "192.169.1.1", r["k2"]

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -119,9 +119,9 @@ class AnonymizerFilterTest < Test::Unit::TestCase
         'host1' => '10.102.0.0'
       },
       'nested' => {
-        'data' => '774472f0dc892f0b3299cae8dadacd0a74ba59d7',
+        'data' => '8cb2237d0679ca88db6464eac60da96345513964',
         'nested' => {
-          'data' => '774472f0dc892f0b3299cae8dadacd0a74ba59d7'
+          'data' => '8cb2237d0679ca88db6464eac60da96345513964'
         }
       }
     }
@@ -143,8 +143,8 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     ]
     expected = {
       'host' => '10.102.3.0',
-      'array' => ["c1628fc0d473cb21b15607c10bdcad19d1a42e24", "ea87abc249f9f2d430edb816514bffeffd3e698e"],
-      'hash' => '28fe85deb0d1d39ee14c49c62bc4773b0338247b'
+      'array' => ["e3cbba8883fe746c6e35783c9404b4bc0c7ee9eb", "a4ac914c09d7c097fe1f4f96b897e625b6922069"],
+      'hash' => '1a1903d78aed9403649d61cb21ba6b489249761b'
     }
     filtered = filter(conf, messages)
     assert_equal(expected, filtered[0])

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -57,11 +57,11 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     ]
     expected = {
       'host'            => '10.102.3.0',
-      'data_for_md5'    => 'e738cbde82a514dc60582cd467c240ed',
-      'data_for_sha1'   => '69cf099459c06b852ede96d39b710027727d13c6',
-      'data_for_sha256' => '804d83b8c6a3e01498d40677652b084333196d8e548ee5a8710fbd0e1e115527',
-      'data_for_sha384' => '6c90c389bbdfc210416b9318df3f526b4f218f8a8df3a67020353c35da22dc154460b18f22a8009a747b3ef2975acae7',
-      'data_for_sha512' => 'cdbb897e6f3a092161bdb51164eb2996b75b00555f568219628ff15cd2929865d217af5dff9c32ddc908b75a89baec96b3e9a0da120e919f5246de0f1bc54c58'
+      'data_for_md5'    => '9138bd41172f5485f7b6eee3afcd0d62',
+      'data_for_sha1'   => 'ee98db51658d38580b1cf788db19ad06e51a32f7',
+      'data_for_sha256' => 'd53d15615b19597b0f95a984a132ed5164ba9676bf3cb28e018d28feaa2ea6fd',
+      'data_for_sha384' => '6e9cd6d84ea371a72148b418f1a8cb2534da114bc2186d36ec6f14fd5c237b6f2e460f409dda89b7e42a14b7da8a8131',
+      'data_for_sha512' => 'adcf4e5d1e52f57f67d8b0cd85051158d7362103d7ed4cb6302445c2708eff4b17cb309cf5d09fd5cf76615c75652bd29d1707ce689a28e8700afd7a7439ef20'
     }
     filtered = filter(CONFIG, messages)
     assert_equal(expected, filtered[0])
@@ -86,9 +86,9 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     expected = {
       'host'      => '10.102.0.0',
       'host2'     => '10.102.0.0',
-      'member_id' => '774472f0dc892f0b3299cae8dadacd0a74ba59d7',
-      'mail'      => 'd7b728209f5dd8df10cecbced30394c3c7fc2c82',
-      'telephone' => 'a67f73c395105a358a03a0f127bf64b5495e7841',
+      'member_id' => '8cb2237d0679ca88db6464eac60da96345513964',
+      'mail'      => '914fec35ce8bfa1a067581032f26b053591ee38a',
+      'telephone' => 'ce164718b94212332187eb8420903b46b334d609',
       'action'    => 'signup'
     }
     filtered = filter(conf, messages)

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -26,11 +26,58 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     d = create_driver(conf)
     d.run {
       messages.each {|message|
-        d.filter(message, @time)
+        d.emit(message, @time)
       }
     }
     filtered = d.filtered_as_array
     filtered.map {|m| m[2] }
+  end
+
+  require 'ostruct'
+  test 'method md5 works correctly' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:md5].call(OpenStruct.new)
+    digest = conv.call('value1', 'salt')
+    assert_equal 'd21fe9523421f12daad064fd082913fd', digest
+  end
+  test 'method sha1 works correctly' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:sha1].call(OpenStruct.new)
+    digest = conv.call('value2', 'salt')
+    assert_equal 'd2ed8e797065322371012fd8c1a39682987ddb71', digest
+  end
+  test 'method sha256 works correctly' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:sha256].call(OpenStruct.new)
+    digest = conv.call('value3', 'salt')
+    assert_equal 'd70daf9654b8a3ba335f8f9f9638a93e8eba6763a0012ac44a928857871abe82', digest
+  end
+  test 'method sha384 works correctly' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:sha384].call(OpenStruct.new)
+    digest = conv.call('value4', 'salt')
+    assert_equal '646192f8b1ea905238df589a00a10598a53eb245df4ab14b7e9eccf80c37386c99abe5259ccb2ba950003423fa0790ee', digest
+  end
+  test 'method sha512 works correctly' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:sha512].call(OpenStruct.new)
+    digest = conv.call('value5', 'salt')
+    expected = '47c82bfea3783c20e3ba3629f0f827bebf0fa65a9104ada5339e5776e5958f061fe7114bfbe1e9d410aff43c6bee8365adf4fdd072e54ab4fffad820f354f545'
+    assert_equal expected, digest
+  end
+  test 'method uri_path removes path, query parameters, fragment, user and password of uri strings' do
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:uri_path].call(OpenStruct.new)
+    assert_equal '/my/path', conv.call('/my/path', '')
+    assert_equal 'yay/unknown/format', conv.call('yay/unknown/format', '')
+    assert_equal 'http://example.com/', conv.call('http://example.com/path/to/secret', '')
+    assert_equal 'http://example.com/', conv.call('http://example.com/path/to/secret?a=b', '')
+    assert_equal 'http://example.com/', conv.call('http://example.com/path/to/secret#xxx', '')
+    assert_equal 'http://example.com/', conv.call('http://example.com/path/to/secret?a=b#xxx', '')
+    assert_equal 'http://example.com/', conv.call('http://tagomoris:secret!@example.com/', '')
+    assert_equal 'http://example.com/', conv.call('http://tagomoris:secret!@example.com/?a=b#xxx', '')
+    assert_equal 'http://example.com/', conv.call('http://tagomoris:secret!@example.com/path/to/secret?a=b#xxx', '')
+  end
+  test 'method network masks ipaddresses with specified mask bit lengths' do
+    conf = OpenStruct.new(ipv4_mask_bits: 24, ipv6_mask_bits: 104)
+    conv = Fluent::AnonymizerFilter::MASK_METHODS[:network].call(conf)
+    assert_equal '192.168.1.0', conv.call('192.168.1.1', '')
+    assert_equal '10.110.18.0', conv.call('10.110.18.9', '')
+    assert_equal '2001:db8:0:8d3:0:8a2e::', conv.call('2001:db8:0:8d3:0:8a2e:70:7344', '')
   end
 
   def test_configure
@@ -42,6 +89,72 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     }
     d = create_driver(CONFIG)
     assert_equal 'test_salt_string', d.instance.config['hash_salt']
+  end
+
+  test 'masker_for_key generates a lambda for conversion with exact key match' do
+    plugin = create_driver.instance
+    conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
+    masker = plugin.masker_for_key(conv, 'kkk', 's')
+    r = masker.call({"k" => "x", "kk" => "xx", "kkk" => "xxx", "kkkk" => "xxxx"})
+    assert_equal "x", r["k"]
+    assert_equal "xx", r["kk"]
+    assert_equal "XXX:s", r["kkk"]
+    assert_equal "xxxx", r["kkkk"]
+    assert_equal 4, r.size
+  end
+
+  test 'masker_for_key_pattern generates a lambda for conversion with key pattern match' do
+    plugin = create_driver.instance
+    conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
+    masker = plugin.masker_for_key_pattern(conv, '^k+$', 's')
+    r = masker.call({"k" => "x", "kk" => "xx", "kkk" => "xxx", "kkk0" => "xxxx", "f" => "x", "ff" => "xx"})
+    assert_equal "X:s", r["k"]
+    assert_equal "XX:s", r["kk"]
+    assert_equal "XXX:s", r["kkk"]
+    assert_equal "xxxx", r["kkk0"]
+    assert_equal "x", r["f"]
+    assert_equal "xx", r["ff"]
+    assert_equal 6, r.size
+  end
+
+  test 'masker_for_value_pattern' do
+    plugin = create_driver.instance
+    conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
+    masker = plugin.masker_for_value_pattern(conv, '^x+$', 's')
+    r = masker.call({"k" => "x", "kk" => "x0", "kkk" => "xx0", "kkk0" => "xxxx", "f" => "x", "ff" => "xx"})
+    assert_equal "X:s", r["k"]
+    assert_equal "x0", r["kk"]
+    assert_equal "xx0", r["kkk"]
+    assert_equal "XXXX:s", r["kkk0"]
+    assert_equal "X:s", r["f"]
+    assert_equal "XX:s", r["ff"]
+    assert_equal 6, r.size
+  end
+
+  test 'masker_for_value_in_subnet' do
+    plugin = create_driver.instance
+    conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
+    masker = plugin.masker_for_value_in_subnet(conv, '192.168.0.0/16', 's')
+    r = masker.call({"k1" => "x", "k2" => "192.169.1.1", "k3" => "192.168.128.13", "f1" => "x", "f2" => "10.0.12.1", "f3" => "192.168.1.1"})
+    assert_equal "x", r["k1"]
+    assert_equal "192.169.1.1", r["k2"]
+    assert_equal "192.168.128.13:s", r["k3"]
+    assert_equal "x", r["f1"]
+    assert_equal "10.0.12.1", r["f2"]
+    assert_equal "192.168.1.1:s", r["f3"]
+  end
+
+  test 'filter plugin can mask specified fields' do
+    plugin = create_driver(<<-CONF).instance
+      <mask md5>
+        salt testing
+        key  test
+      </mask>
+CONF
+    r = plugin.filter('tag', Time.now.to_i, {"test" => "value", "name" => "fluentd plugin"})
+    assert_equal 2, r.size
+    assert_equal "fluentd plugin", r["name"]
+    assert_equal "6255093f2e4204e24df48ddd7f4a8abe", r["test"]
   end
 
   def test_filter

--- a/test/plugin/test_filter_anonymizer.rb
+++ b/test/plugin/test_filter_anonymizer.rb
@@ -104,6 +104,21 @@ class AnonymizerFilterTest < Test::Unit::TestCase
     assert_equal 4, r.size
   end
 
+  test 'masker_for_key_chain generates a lambda for conversion with recursive key fetching' do
+    conf = OpenStruct.new(salt: 's')
+    plugin = create_driver.instance
+    conv = ->(v,salt){ "#{v.upcase}:#{salt}" } # it's dummy for test
+    masker = plugin.masker_for_key_chain(conv, 'a.b.c'.split('.'), conf)
+    event = {
+      'a' => {
+        'b' => { 'c' => 'v', 'd' => 'v' }
+      }
+    }
+    r = masker.call(event)
+    assert_equal 'V:s', r['a']['b']['c']
+    assert_equal 'v', r['a']['b']['d']
+  end
+
   test 'masker_for_key_pattern generates a lambda for conversion with key pattern match' do
     conf = OpenStruct.new(salt: 's')
     plugin = create_driver.instance

--- a/test/plugin/test_out_anonymizer.rb
+++ b/test/plugin/test_out_anonymizer.rb
@@ -49,11 +49,11 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     assert_equal 1, emits.length
     assert_equal 'anonymized.access', emits[0][0] # tag
     assert_equal '10.102.3.0', emits[0][2]['host']
-    assert_equal 'e738cbde82a514dc60582cd467c240ed', emits[0][2]['data_for_md5']
-    assert_equal '69cf099459c06b852ede96d39b710027727d13c6', emits[0][2]['data_for_sha1']
-    assert_equal '804d83b8c6a3e01498d40677652b084333196d8e548ee5a8710fbd0e1e115527', emits[0][2]['data_for_sha256']
-    assert_equal '6c90c389bbdfc210416b9318df3f526b4f218f8a8df3a67020353c35da22dc154460b18f22a8009a747b3ef2975acae7', emits[0][2]['data_for_sha384']
-    assert_equal 'cdbb897e6f3a092161bdb51164eb2996b75b00555f568219628ff15cd2929865d217af5dff9c32ddc908b75a89baec96b3e9a0da120e919f5246de0f1bc54c58', emits[0][2]['data_for_sha512']
+    assert_equal '9138bd41172f5485f7b6eee3afcd0d62', emits[0][2]['data_for_md5']
+    assert_equal 'ee98db51658d38580b1cf788db19ad06e51a32f7', emits[0][2]['data_for_sha1']
+    assert_equal 'd53d15615b19597b0f95a984a132ed5164ba9676bf3cb28e018d28feaa2ea6fd', emits[0][2]['data_for_sha256']
+    assert_equal '6e9cd6d84ea371a72148b418f1a8cb2534da114bc2186d36ec6f14fd5c237b6f2e460f409dda89b7e42a14b7da8a8131', emits[0][2]['data_for_sha384']
+    assert_equal 'adcf4e5d1e52f57f67d8b0cd85051158d7362103d7ed4cb6302445c2708eff4b17cb309cf5d09fd5cf76615c75652bd29d1707ce689a28e8700afd7a7439ef20', emits[0][2]['data_for_sha512']
   end
 
   def test_emit_multi_keys
@@ -79,9 +79,9 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     assert_equal 'anonymized.access', emits[0][0] # tag
     assert_equal '10.102.0.0', emits[0][2]['host']
     assert_equal '10.102.0.0', emits[0][2]['host2']
-    assert_equal '774472f0dc892f0b3299cae8dadacd0a74ba59d7', emits[0][2]['member_id']
-    assert_equal 'd7b728209f5dd8df10cecbced30394c3c7fc2c82', emits[0][2]['mail']
-    assert_equal 'a67f73c395105a358a03a0f127bf64b5495e7841', emits[0][2]['telephone']
+    assert_equal '8cb2237d0679ca88db6464eac60da96345513964', emits[0][2]['member_id']
+    assert_equal '914fec35ce8bfa1a067581032f26b053591ee38a', emits[0][2]['mail']
+    assert_equal 'ce164718b94212332187eb8420903b46b334d609', emits[0][2]['telephone']
     assert_equal 'signup', emits[0][2]['action']
   end
 
@@ -110,8 +110,8 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     assert_equal 1, emits.length
     assert_equal 'anonymized.access', emits[0][0] # tag
     assert_equal '10.102.0.0', emits[0][2]['hosts']['host1']
-    assert_equal '774472f0dc892f0b3299cae8dadacd0a74ba59d7', emits[0][2]['nested']['data']
-    assert_equal '774472f0dc892f0b3299cae8dadacd0a74ba59d7', emits[0][2]['nested']['nested']['data']
+    assert_equal '8cb2237d0679ca88db6464eac60da96345513964', emits[0][2]['nested']['data']
+    assert_equal '8cb2237d0679ca88db6464eac60da96345513964', emits[0][2]['nested']['nested']['data']
   end
 
   def test_emit_nest_value
@@ -170,7 +170,7 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     emits = d1.emits
     assert_equal 1, emits.length
     assert_equal 'anonymized.message', emits[0][0] # tag
-    assert_equal '774472f0dc892f0b3299cae8dadacd0a74ba59d7', emits[0][2]['member_id']
+    assert_equal '8cb2237d0679ca88db6464eac60da96345513964', emits[0][2]['member_id']
   end
 
   def test_emit_tag_placeholder
@@ -187,7 +187,7 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     emits = d1.emits
     assert_equal 1, emits.length
     assert_equal 'anonymized.access', emits[0][0] # tag
-    assert_equal '774472f0dc892f0b3299cae8dadacd0a74ba59d7', emits[0][2]['member_id']
+    assert_equal '8cb2237d0679ca88db6464eac60da96345513964', emits[0][2]['member_id']
   end
 end
 

--- a/test/plugin/test_out_anonymizer.rb
+++ b/test/plugin/test_out_anonymizer.rb
@@ -132,8 +132,8 @@ class AnonymizerOutputTest < Test::Unit::TestCase
     assert_equal 1, emits.length
     assert_equal 'anonymized.access', emits[0][0] # tag
     assert_equal '10.102.3.0', emits[0][2]['host']
-    assert_equal ["c1628fc0d473cb21b15607c10bdcad19d1a42e24", "ea87abc249f9f2d430edb816514bffeffd3e698e"], emits[0][2]['array']
-    assert_equal '28fe85deb0d1d39ee14c49c62bc4773b0338247b', emits[0][2]['hash']
+    assert_equal ["e3cbba8883fe746c6e35783c9404b4bc0c7ee9eb", "a4ac914c09d7c097fe1f4f96b897e625b6922069"], emits[0][2]['array']
+    assert_equal '1a1903d78aed9403649d61cb21ba6b489249761b', emits[0][2]['hash']
   end
 
   def test_emit_ipv6


### PR DESCRIPTION
This re-implementation is to:
- make it possible to use 2 or more salts
- mask values as key patterns
- mask values as value patterns
- mask ip addresses in specified subnets (good for logs like forward proxy servers to mask client address)
- mask paths and credentials in URIs (same with above)

And make whole design extensible for more features if needed.

@y-ken How do you think about this implementation?
I'll fix README and output plugin (based on filter plugin) if it's ok to merge.
This change is based on #15 .
