### PR TITLE
Add dependent Fluentd version explicitly

### DIFF
--- a/fluent-plugin-anonymizer.gemspec
+++ b/fluent-plugin-anonymizer.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "test-unit", "~> 3"
   spec.add_development_dependency "appraisal"
-  spec.add_runtime_dependency "fluentd"
+  spec.add_runtime_dependency "fluentd", [">= 0.14.0", "< 2"]
   spec.add_runtime_dependency "fluent-mixin-rewrite-tag-name"
 end


### PR DESCRIPTION
This is a preparing task of https://github.com/y-ken/fluent-plugin-anonymizer/issues/21.
filter_anonymizer is already v0.14 ready and we will plan to drop out_anonymizer.
So, we can specify dependent Fluentd version.